### PR TITLE
Add caching of provisioned access tokens with expiration awareness.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 API_STACK_NAME	:= auth0-cis-webhook-consumer
 CODE_STORAGE_S3_PREFIX := auth0-cis-webhook-consumer
-PROD_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME := public.us-west-2.iam.mozilla.com
-DEV_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME  := public.us-west-2.iam.mozilla.com
-TEST_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME  := public.us-west-2.iam.mozilla.com
+LAMBDA_CODE_STORAGE_S3_BUCKET_NAME := public.us-west-2.iam.mozilla.com
 PROD_DOMAIN_NAME	:= auth0-cis-webhook-consumer.sso.mozilla.com
 DEV_DOMAIN_NAME		:= auth0-cis-webhook-consumer.dev.sso.allizom.org
 TEST_DOMAIN_NAME	:= auth0-cis-webhook-consumer.test.sso.allizom.org
@@ -46,7 +44,7 @@ DEV_MANAGEMENT_DISCOVERY_URL	:= https://auth-dev.mozilla.auth0.com/.well-known/o
 PROD_MANAGEMENT_API_AUDIENCE	:= https://auth.mozilla.auth0.com/api/v2/
 DEV_MANAGEMENT_API_AUDIENCE		:= https://auth-dev.mozilla.auth0.com/api/v2/
 
-USER_WHITELIST	:= ad|Mozilla-LDAP|gene,ad|Mozilla-LDAP|FMerz
+USER_WHITELIST	:= ad|Mozilla-LDAP|gene,ad|Mozilla-LDAP|FMerz,ad|Mozilla-LDAP-Dev|gene,ad|Mozilla-LDAP-Dev|FMerz,ad|Mozilla-LDAP|hcondei,ad|Mozilla-LDAP-Dev|hcondei
 # USER_WHITELIST	:= ""
 
 .PHONY: deploy-dev
@@ -54,7 +52,7 @@ deploy-dev:
 	./deploy.sh \
 		$(ACCOUNT_ID) \
 		 auth0-cis-webhook-consumer.yaml \
-		 $(DEV_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME) \
+		 $(LAMBDA_CODE_STORAGE_S3_BUCKET_NAME) \
 		 $(API_STACK_NAME)-$(DEV_ENVIRONMENT_NAME) \
 		 $(CODE_STORAGE_S3_PREFIX) \
 		 "CustomDomainName=$(DEV_DOMAIN_NAME) \
@@ -72,12 +70,34 @@ deploy-dev:
 			ManagementAPIDiscoveryUrl=$(DEV_MANAGEMENT_DISCOVERY_URL)" \
 		 Auth0CISWebHookConsumerUrl
 
+deploy-test:
+	./deploy.sh \
+		$(ACCOUNT_ID) \
+		 auth0-cis-webhook-consumer.yaml \
+		 $(LAMBDA_CODE_STORAGE_S3_BUCKET_NAME) \
+		 $(API_STACK_NAME)-$(TEST_ENVIRONMENT_NAME) \
+		 $(CODE_STORAGE_S3_PREFIX) \
+		 "CustomDomainName=$(TEST_DOMAIN_NAME) \
+		 	DomainNameZone=$(TEST_DOMAIN_ZONE) \
+		 	CertificateArn=$(TEST_CERT_ARN) \
+			EnvironmentName=$(TEST_ENVIRONMENT_NAME) \
+			UserWhitelist=$(USER_WHITELIST) \
+			NotificationDiscoveryUrl=$(PROD_NOTIFICATION_DISCOVERY_URL) \
+			NotificationAudience=$(TEST_NOTIFICATION_AUDIENCE) \
+			PersonAPIDiscoveryUrl=$(PROD_PERSONAPI_DISCOVERY_URL) \
+			PersonAPIClientID=$(PROD_PERSONAPI_CLIENT_ID) \
+			PersonAPIAudience=$(TEST_PERSONAPI_AUDIENCE) \
+			ManagementAPIClientID=$(DEV_MANAGEMENT_API_CLIENT_ID) \
+			ManagementAPIAudience=$(DEV_MANAGEMENT_API_AUDIENCE) \
+			ManagementAPIDiscoveryUrl=$(DEV_MANAGEMENT_DISCOVERY_URL)" \
+		 Auth0CISWebHookConsumerUrl
+
 .PHONY: deploy
 deploy:
 	./deploy.sh \
 		$(ACCOUNT_ID) \
 		 auth0-cis-webhook-consumer.yaml \
-		 $(PROD_LAMBDA_CODE_STORAGE_S3_BUCKET_NAME) \
+		 $(LAMBDA_CODE_STORAGE_S3_BUCKET_NAME) \
 		 $(API_STACK_NAME)-$(PROD_ENVIRONMENT_NAME) \
 		 $(CODE_STORAGE_S3_PREFIX) \
 		 "CustomDomainName=$(PROD_DOMAIN_NAME) \

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ for me to get this up and running.
 
 # Architecture
 
-* `auth0-cis-webhook-consumer.dev.sso.allizom.org.` DNS record in `mozilla-iam`
+* `auth0-cis-webhook-consumer.test.sso.allizom.org.` DNS record in `mozilla-iam`
   AWS account is an alias to AWS API Gateway
 * API Gateway proxies all request to AWS Lambda function
 * Lambda function calls appropriate Python function based on the URL path in the
@@ -152,23 +152,24 @@ make deploy-dev
 
 ```
 curl -d '{"foo": "bar"}' -i \
-  https://auth0-cis-webhook-consumer.dev.sso.allizom.org/test
+  https://auth0-cis-webhook-consumer.test.sso.allizom.org/test
 curl -d '{"foo": "bar"}' -i \
-  https://auth0-cis-webhook-consumer.dev.sso.allizom.org/error
+  https://auth0-cis-webhook-consumer.test.sso.allizom.org/error
 curl -d '{"foo": "bar"}' -i \
-  https://auth0-cis-webhook-consumer.dev.sso.allizom.org/404
+  https://auth0-cis-webhook-consumer.test.sso.allizom.org/404
 ```
 
 ### Getting a Bearer Token to Impersonate CIS Webhook Publisher
 
 * Copy paste the `curl` command to provision a token from the API in dev or prod
-  * https://manage.mozilla.auth0.com/dashboard/pi/auth/apis/5c80d6ddaf6977386c57d06f/test
+  * [`hook.dev.sso.allizom.org`](https://manage.mozilla.auth0.com/dashboard/pi/auth/apis/5c80d6ddaf6977386c57d06f/test)
+  * [`hook.test.sso.allizom.org`](https://manage.mozilla.auth0.com/dashboard/pi/auth/apis/5c9c0950c32ba0449dd355c4/test)
 * Take the `access_token` value and use it in the `${TOKEN}` section of this
 
 ```
 curl -H  "Authorization: Bearer ${TOKEN}" \
   -d '{"operation": "update", "id": "ad|Mozilla-LDAP|dinomcvouch"}' -i \
-  https://auth0-cis-webhook-consumer.dev.sso.allizom.org/post
+  https://auth0-cis-webhook-consumer.test.sso.allizom.org/post
 ```
 
 # Diagrams
@@ -211,12 +212,12 @@ graph TD
 ```mermaid
 graph TD
   hook.test.sso.mozilla.com -->|prod Auth0 token| auth0-cis-webhook-consumer.test.sso.allizom.org
-  auth0-cis-webhook-consumer.test.sso.allizom.org -->|prod Auth0 token| person.api.sso.mozilla.com
+  auth0-cis-webhook-consumer.test.sso.allizom.org -->|prod Auth0 token| person.api.test.sso.mozilla.com
   auth0-cis-webhook-consumer.test.sso.allizom.org -->|dev Auth0 token| auth-dev.mozilla.auth0.com/api/v2/
   linkStyle 2 stroke:#ff3,stroke-width:4px,color:red;
   style hook.test.sso.mozilla.com fill:#fcf
   style auth0-cis-webhook-consumer.test.sso.allizom.org fill:#fcf
-  style person.api.sso.mozilla.com fill:#ccf
+  style person.api.test.sso.mozilla.com fill:#fcf
   style auth-dev.mozilla.auth0.com/api/v2/ fill:#cfd
 ```
 

--- a/functions/auth0_cis_webhook_consumer/app.py
+++ b/functions/auth0_cis_webhook_consumer/app.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import traceback
+import os
 
 from .config import Config
 
@@ -18,8 +19,8 @@ logging.getLogger().handlers[0].setFormatter(formatter)
 logging.getLogger('boto3').propagate = False
 logging.getLogger('botocore').propagate = False
 logging.getLogger('urllib3').propagate = False
+logging.getLogger().setLevel(os.getenv('LOG_LEVEL', 'INFO'))
 CONFIG = Config()
-logging.getLogger().setLevel(CONFIG.log_level)
 
 
 def process_api_call(
@@ -84,7 +85,6 @@ def lambda_handler(event: dict, context: dict) -> dict:
     :param context: Lambda context about the invocation and environment
     :return: An AWS API Gateway output dictionary for proxy mode
     """
-    logger.debug('event is {}'.format(event))
     if event.get('resource') == '/{proxy+}':
         try:
             headers = (


### PR DESCRIPTION
* Fix logging in the config module
* Remove overly verbose debug logging
* Add make target for deploying to the test environment
* Change method get_authorization
  * to accept a discovery document instead of merely the token endpoint URL from the discover document. This allows us to see the issuer and audience to use as keys when caching the access token we get back from Auth0
  * to return just the access token, not "Bearer ..."
* The access token caching only persists as long as the Lambda function is warm. We could later try persisting the token into a data store as it's valid for 24 hours