### PR TITLE
Add support for ratelimiting

### DIFF
--- a/auth0-cis-webhook-consumer.yaml
+++ b/auth0-cis-webhook-consumer.yaml
@@ -229,7 +229,7 @@ Resources:
       # resource is created, creating the LogGroup with no expiration and
       # preventing this resource from creating
       LogGroupName: !Join [ '/', ['/aws/lambda', !Ref 'Auth0CISWebHookConsumerAsyncFunction' ] ]
-      RetentionInDays: 14
+      RetentionInDays: 30
   Auth0CISWebHookConsumerDomainName:
     Type: AWS::ApiGateway::DomainName
     Condition: UseCustomDomainName

--- a/functions/auth0_cis_webhook_consumer/app.py
+++ b/functions/auth0_cis_webhook_consumer/app.py
@@ -9,6 +9,7 @@ from .utils import (
     verify_token,
     process_auth0_user
 )
+from .lambda_types import LambdaDict, LambdaContext
 
 logger = logging.getLogger()
 if len(logging.getLogger().handlers) == 0:
@@ -24,12 +25,14 @@ CONFIG = Config()
 
 
 def process_api_call(
-        event: dict,
+        event: LambdaDict,
+        context: LambdaContext,
         cis_webhook_authorization: str,
         body: dict) -> dict:
     """Process an API Gateway call depending on the URL path called
 
     :param event: The API Gateway request event
+    :param context: AWS Lambda context object
     :param cis_webhook_authorization: A bearer token from the CIS webhook
            service
     :param body: The parsed body that was POSTed to the API Gateway
@@ -78,7 +81,7 @@ def process_api_call(
             'body': "That path wasn't found"}
 
 
-def lambda_handler(event: dict, context: dict) -> dict:
+def lambda_handler(event: LambdaDict, context: LambdaContext) -> LambdaDict:
     """Handler for all API Gateway requests
 
     :param event: AWS API Gateway input fields for AWS Lambda

--- a/functions/auth0_cis_webhook_consumer/app.py
+++ b/functions/auth0_cis_webhook_consumer/app.py
@@ -89,6 +89,17 @@ def lambda_handler(event: LambdaDict, context: LambdaContext) -> LambdaDict:
     :return: An AWS API Gateway output dictionary for proxy mode
     """
     if event.get('resource') == '/{proxy+}':
+        if event.get('httpMethod') != 'POST':
+            return {
+                'headers': {'Content-Type': 'text/html'},
+                'statusCode': 405,
+                'body': '405 Method Not Allowed'}
+        elif not event.get('body'):
+            logger.debug('Missing POST body')
+            return {
+                'headers': {'Content-Type': 'text/html'},
+                'statusCode': 400,
+                'body': 'Missing POST body'}
         try:
             headers = (
                 {x.lower(): event['headers'][x] for x in event['headers']}

--- a/functions/auth0_cis_webhook_consumer/lambda_types.py
+++ b/functions/auth0_cis_webhook_consumer/lambda_types.py
@@ -1,0 +1,39 @@
+""" Note: this code is used only by the static type checker """
+from typing import Dict, Any
+
+LambdaDict = Dict[str, Any]
+
+
+class LambdaCognitoIdentity(object):
+    cognito_identity_id: str
+    cognito_identity_pool_id: str
+
+
+class LambdaClientContextMobileClient(object):
+    installation_id: str
+    app_title: str
+    app_version_name: str
+    app_version_code: str
+    app_package_name: str
+
+
+class LambdaClientContext(object):
+    client: LambdaClientContextMobileClient
+    custom: LambdaDict
+    env: LambdaDict
+
+
+class LambdaContext(object):
+    function_name: str
+    function_version: str
+    invoked_function_arn: str
+    memory_limit_in_mb: int
+    aws_request_id: str
+    log_group_name: str
+    log_stream_name: str
+    identity: LambdaCognitoIdentity
+    client_context: LambdaClientContext
+
+    @staticmethod
+    def get_remaining_time_in_millis() -> int:
+        return 0

--- a/functions/auth0_cis_webhook_consumer/utils.py
+++ b/functions/auth0_cis_webhook_consumer/utils.py
@@ -4,7 +4,7 @@ import time
 import requests
 import urllib.parse
 from jose import jwt, exceptions
-from typing import Optional
+from typing import Optional, Callable
 
 from .config import Config
 


### PR DESCRIPTION
Consume Auth0 ratelimit headers to detect when ratelimiting has or is going to happen.
If we can sleep until ratelimiting resets before we run out of Lambda execution time
then we will. This isn't perfect as this is a serverless function just sitting and sleeping
when really we should queue up the job to come back to, finish and spawn later.

This doesn't handle the scenario where Auth0 ratelimits and won't reset before
the Lambda function runs out of time.

Fixes #8 

Also
* Detect non POST method calls and ignore
* Add type hinting for event and context
* Change log retention to 30 days