### PR TITLE
Tests fail because we don't define a default region

### DIFF
--- a/test/test_config.py
+++ b/test/test_config.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 def test_get_secret_value_success():
 
     """Test Configuration getting secrets from AWS Secrets Manager"""
+    os.environ['AWS_DEFAULT_REGION'] = 'us-west-2'
     os.environ['AWS_ACCESS_KEY_ID'] = 'fake-access-key'
     os.environ['AWS_SECRET_ACCESS_KEY'] = 'fake-secret-key'
     os.environ['AWS_SECURITY_TOKEN'] = 'fake-security-token'


### PR DESCRIPTION
Potentially this worked locally because there was a default region configured, or perhaps the mocking code changed?

Jira: [IAM-1043](https://mozilla-hub.atlassian.net/browse/IAM-1043)